### PR TITLE
Minor typo in example description

### DIFF
--- a/examples/fr.lip6.move.gal.examples/examples/classics/Sources.txt
+++ b/examples/fr.lip6.move.gal.examples/examples/classics/Sources.txt
@@ -1,4 +1,4 @@
-These are various classic models from the litterature.
+These are various classic models from the literature.
 They are layout by neato, as they were extracted from textual formats lacking graphical positions.
 
 Ring, Philo, and Kanban are scalable models used in Gianfranco Ciardo's benchmarks for SMART (see PNPM'99 paper for instance)

--- a/examples/fr.lip6.move.gal.examples/plugin.xml
+++ b/examples/fr.lip6.move.gal.examples/plugin.xml
@@ -85,7 +85,7 @@
             name="Classic P/T examples"
             project="true">
          <description>
-            This project contains several classic Petri net examples taken from the litterature.
+            This project contains several classic Petri net examples taken from the literature.
          </description>
       </wizard>
             <wizard


### PR DESCRIPTION
Hardly worth a pull request, but I stumbled upon a typo while looking into the introductory GAL examples.

ps. Thanks for the awesome tooling -- love the separation of libDDD, libITS, and the higher-level procedures.